### PR TITLE
<update>: integrate metric meter to a new class

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -88,3 +88,10 @@ class SLATrainerConfig(BaseTrainerConfig):
     T: float
     alpha: float
     update_interval: int
+    
+@dataclass
+class MetricMeter:
+    counter: int = 0
+    best_acc: float = 0
+    best_val_acc: float = 0
+    start_time: float = 0


### PR DESCRIPTION
To record all necessary metrics during training, we have added a new dataclass called `MetricMeter`.

Currently, `MetricMeter` tracks four metrics:

1. `best_val_acc`: This metric records the best validation accuracy achieved during the training process.
2. `best_acc`: This metric records the test accuracy achieved at the iteration when `best_val_acc` was obtained.
3. `counter`: This metric records the number of contiguous iterations that the validation accuracy is lower than `best_val_acc`. This is useful for early stopping.
4. `start_time`: This metric records the relative starting time of the training progress.